### PR TITLE
Add appropiate ifdefs for Linux

### DIFF
--- a/NodeCoreAudio/AudioEngine.cpp
+++ b/NodeCoreAudio/AudioEngine.cpp
@@ -13,6 +13,12 @@
 #include <node_internals.h>
 #include <node_object_wrap.h>
 #include <stdlib.h>
+
+#ifdef __linux__
+	#include <unistd.h>
+	#include <string.h>
+#endif
+
 using namespace v8;
 
 Persistent<Function> Audio::AudioEngine::constructor;
@@ -400,10 +406,10 @@ void Audio::AudioEngine::RunAudioLoop(){
 			m_bOutputUnderflowed = (error != paNoError);
 		} else {
 			m_bOutputUnderflowed = true;
-#ifdef __APPLE__
-			sleep(1);
-#else
+#ifdef __WINDOWS__
 			Sleep(1);
+#else
+			sleep(1);
 #endif
 		}
 	}

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ var engine = coreAudio.createNewAudioEngine();
 //
 // Note: This function must return an output buffer
 function processAudio( inputBuffer ) {
-	console.log( inputBuffer.length + " channels" );
-	console.log( "Channel 0 has " = inputBuffer[0].length + " samples" );
+	console.log( "%d channels", inputBuffer.length );
+	console.log( "Channel 0 has %d samples", inputBuffer[0].length );
 
 	return inputBuffer;
 }


### PR DESCRIPTION
unistd.h is required for sleep
string.h is required for memcpy

Only Windows appears to have sleep with a capital S, all other (unix based) operation systems appear to use the lower case name.