### PR TITLE
Add std namespace use

### DIFF
--- a/NodeCoreAudio/AudioEngine.cpp
+++ b/NodeCoreAudio/AudioEngine.cpp
@@ -19,7 +19,7 @@
 	#include <string.h>
 #endif
 
-using namespace v8;
+using namespace v8; using namespace std;
 
 Persistent<Function> Audio::AudioEngine::constructor;
 


### PR DESCRIPTION
On linux, the lib won't install because of the use of std functions (memcpy and sleep) without declaring the std namespace.