### PR TITLE
Fixing warnings and a bug

### DIFF
--- a/NodeCoreAudio/AudioEngine.cpp
+++ b/NodeCoreAudio/AudioEngine.cpp
@@ -33,8 +33,7 @@ static void do_work( void* arg ) {
 Audio::AudioEngine::AudioEngine( Local<Object> options ) :
 	m_uSampleSize(4),
 	m_pIsolate(Isolate::GetCurrent()),
-	m_pLocker(new Locker(Isolate::GetCurrent())),
-	m_bOutputIsEmpty(true) {
+	m_pLocker(new Locker(Isolate::GetCurrent())) {
 
 	PaError openStreamErr;
 	m_pPaStream = NULL;
@@ -217,7 +216,7 @@ void Audio::AudioEngine::applyOptions( Local<Object> options ) {
 	if( m_cachedInputSampleBlock != NULL )
 		free( m_cachedInputSampleBlock );
 	if( m_cachedOutputSampleBlock != NULL ) {
-		for (int i = 0; i < oldBufferCount; i++) {
+		for (unsigned int i = 0; i < oldBufferCount; i++) {
 			if ( m_cachedOutputSampleBlock[i] != NULL ) {
 				free(m_cachedOutputSampleBlock[i]);
 			}
@@ -380,7 +379,7 @@ void Audio::AudioEngine::queueOutputBuffer( Handle<Array> result ) {
 /*! Run the main blocking audio loop */
 void Audio::AudioEngine::RunAudioLoop(){
 
-	PaError error;
+	PaError error = 0;
 
 	assert( m_pPaStream );
 

--- a/NodeCoreAudio/AudioEngine.cpp
+++ b/NodeCoreAudio/AudioEngine.cpp
@@ -187,7 +187,7 @@ void Audio::AudioEngine::applyOptions( Local<Object> options ) {
 	if (Nan::HasOwnProperty(options, Nan::New<String>("useMicrophone").ToLocalChecked()).FromMaybe(false) )
 		m_bReadMicrophone = Nan::To<bool>(Nan::Get(options, Nan::New<String>("useMicrophone").ToLocalChecked()).ToLocalChecked()).FromJust();
 	if (Nan::HasOwnProperty(options, Nan::New<String>("sampleRate").ToLocalChecked()).FromMaybe(false) )
-		m_uSampleRate = Nan::To<bool>(Nan::Get(options, Nan::New<String>("sampleRate").ToLocalChecked()).ToLocalChecked()).FromJust();
+		m_uSampleRate = Nan::To<int>(Nan::Get(options, Nan::New<String>("sampleRate").ToLocalChecked()).ToLocalChecked()).FromJust();
 	if(Nan::HasOwnProperty(options, Nan::New<String>("sampleFormat").ToLocalChecked()).FromMaybe(false) ) {
 		switch(Nan::To<int>(Nan::Get(options, Nan::New<String>("sampleFormat").ToLocalChecked()).ToLocalChecked()).FromJust()){
 			case 0x01: m_uSampleFormat = paFloat32; m_uSampleSize = 4; break;

--- a/NodeCoreAudio/AudioEngine.h
+++ b/NodeCoreAudio/AudioEngine.h
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //
 // AudioEngine.cpp: Core audio functionality
-// 
+//
 //////////////////////////////////////////////////////////////////////////////
 
 #pragma once
@@ -41,10 +41,10 @@ namespace Audio {
 		~AudioEngine();		//!< OOL Destructor
 
 	private:
-		static v8::Persistent<v8::Function> constructor;                
+		static v8::Persistent<v8::Function> constructor;
 		//static v8::Handle<v8::Value> New( const v8::Arguments& args );	//!< Create a v8 object
         static NAN_METHOD(New);
-		
+
 		//! Returns whether the PortAudio stream is active
 		//static v8::Handle<v8::Value> isActive( const v8::Arguments& args );
         static NAN_METHOD(isActive);
@@ -64,7 +64,7 @@ namespace Audio {
         static NAN_METHOD(read);
 		//static v8::Handle<v8::Value> isBufferEmpty( const v8::Arguments& args );	//!< Returns whether the data buffer is empty
         static NAN_METHOD(isBufferEmpty);
-		
+
 		//static v8::Handle<v8::Value> setOptions( const v8::Arguments& args );	//!< Set options, restarts audio stream
         static NAN_METHOD(setOptions);
 		//static v8::Handle<v8::Value> getOptions( const v8::Arguments& args );	//!< Gets options
@@ -87,8 +87,7 @@ namespace Audio {
 
 		Local<Array> m_hInputBuffer;		//!< Our pre-allocated input buffer
 
-		uv_thread_t ptStreamThread,			//!< Our stream thread
-					jsAudioThread;			//!< Our JavaScript Audio thread
+		uv_thread_t ptStreamThread;			//!< Our stream thread
 
 		uv_mutex_t m_mutex;					//!< A mutex for transferring data between the DSP and UI threads
 
@@ -107,7 +106,6 @@ namespace Audio {
 
 		bool m_bInputOverflowed,			//!< Set when our buffers have overflowed
 			 m_bOutputUnderflowed,
-			 m_bOutputIsEmpty,
 			 m_bReadMicrophone,
 			 m_bInterleaved;				//!< Set when we're processing interleaved buffers
 
@@ -120,6 +118,5 @@ namespace Audio {
 		Locker* m_pLocker;
 
 	}; // end class AudioEngine
-	
-} // end namespace Audio
 
+} // end namespace Audio

--- a/package.json
+++ b/package.json
@@ -33,12 +33,7 @@
     "streaming",
     "buffer"
   ],
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://raw.github.com/ZECTBynmo/node-core-audio/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "http://github.com/ZECTBynmo/node-core-audio.git"


### PR DESCRIPTION
This should fix:
- several minor compilation warnings (e.g., unused/uninitialized variables),
- an npm warning coming from an incorrect license format in package.json,
- a bug from PR #53 (the sample rate is an integer, not a boolean...)